### PR TITLE
making the collapse caret work as a button instead of a span

### DIFF
--- a/src/dark.css
+++ b/src/dark.css
@@ -871,6 +871,12 @@ img[src="https://fi.somethingawful.com/images/newbie.gif"] {
 	display: none;
 }
 
+.collapse-caret:hover {
+	background: none;
+	box-shadow: none;
+	border: none;
+}  
+
 tr.altcolor1, tr.altcolor2, tr.seen1, tr.seen2 {
 	.expandFade {
 	  mask-image: linear-gradient(180deg, #1b202b 20%, transparent);

--- a/src/forums.css
+++ b/src/forums.css
@@ -4356,10 +4356,16 @@ div.pages select ~ a:last-child, div.pages select ~ a:last-child:hover {
 }
 
 .collapse-caret {
+  margin:0;
   margin-right: 6px;
+  color: inherit;
+  font-family: inherit;
   user-select: none;
-  cursor: pointer;
   font-style: normal;
+  background:none;
+  border:none;
+  padding:0;
+  cursor: pointer;
 }
 
 .collapsableQuote {

--- a/src/forums.css
+++ b/src/forums.css
@@ -4365,6 +4365,7 @@ div.pages select ~ a:last-child, div.pages select ~ a:last-child:hover {
   background:none;
   border:none;
   padding:0;
+  box-shadow: none;
   cursor: pointer;
 }
 


### PR DESCRIPTION
allows the collapse caret to be a `<button/>` without inheriting all the crazy styling