### PR TITLE
Update system message style in YOSPOS and dark mode

### DIFF
--- a/src/219.css
+++ b/src/219.css
@@ -59,6 +59,33 @@ ul#nav_purchase li, #nav_purchase a, #navigation li a, .navigation li a {
 	color: #57FF57!important
 }
 
+#system {
+	border: none;
+	background-color: #57FF57;
+	color: black;
+	font-family: "consolas", "monaco", monospace;
+}
+
+#system a, #system h1 {
+	color: inherit;
+	font-family: inherit;
+}
+
+#system:hover {
+	animation: 2s step-end infinite system-blink;
+}
+
+@keyframes system-blink {
+	0% {
+		background-color: black;
+		color: #57FF57;
+	}
+	50% {
+		background-color: #57FF57;
+		color: black;
+	}
+}
+
 div.pages a {
 	border: 1px solid #57FF57!important;
 	min-width: 30px!important;

--- a/src/219a.css
+++ b/src/219a.css
@@ -59,6 +59,33 @@ ul#nav_purchase li, #nav_purchase a, #navigation li a, .navigation li a {
 	color: #EACF4C!important
 }
 
+#system {
+	border: none;
+	background-color: #EACF4C;
+	color: black;
+	font-family: "consolas", "monaco", monospace;
+}
+
+#system a, #system h1 {
+	color: inherit;
+	font-family: inherit;
+}
+
+#system:hover {
+	animation: 2s step-end infinite system-blink;
+}
+
+@keyframes system-blink {
+	0% {
+		background-color: black;
+		color: #EACF4C;
+	}
+	50% {
+		background-color: #EACF4C;
+		color: black;
+	}
+}
+
 div.pages a {
 	border: 1px solid #EACF4C!important;
 	min-width: 30px!important;

--- a/src/dark.css
+++ b/src/dark.css
@@ -820,7 +820,7 @@ body.forum_267, body.forum_680  {
 
 /* System Message */
 #system {
-	background:#508827;
+	background:#888827;
 	color:#000;
 }
 


### PR DESCRIPTION
YOSPOS change by popular request. I tested things in Safari and Firefox but I've never done CSS animations before, so lemme know if anything looks out of place. Also, I saw some other animations in the same stylesheet use `-webkit`-prefixed animation properties, but AFIAK the unprefixed versions have been widely available for a while so I figured less verbose was better.

The dark mode change is kind of a personal preference, updating the message background from green to a darker shade of yellow. IMO the green isn't very alert-y, and yellow keeps it consistent with light mode - when I first saw the dark mode message it didn't immediately scan as being the same thing as the light mode version I was used to. 