### PR TITLE
Dummy out .cospop and button.nice 

### DIFF
--- a/src/219.css
+++ b/src/219.css
@@ -274,6 +274,7 @@ p.editedby span, p.attachment span, #copyright, #copyright * {
 }
 
 .cospop {
+	display: none;
 	background-color: black!important;
 	border: 1px solid #57FF57!important;
 	cursor: url('https://fi.somethingawful.com/219/cosby/pudding_cursor.png'), default;

--- a/src/219.css
+++ b/src/219.css
@@ -281,6 +281,10 @@ p.editedby span, p.attachment span, #copyright, #copyright * {
 	margin: 0
 }
 
+ul.postbuttons li:last-child {
+	display: none;
+}
+
 button.nice {
 	color: #57FF57!important;
 	background-color: transparent;

--- a/src/219a.css
+++ b/src/219a.css
@@ -279,6 +279,7 @@ p.editedby span, p.attachment span, #copyright, #copyright * {
 }
 
 .cospop {
+	display: none;
 	background-color: black!important;
 	border: 1px solid #EACF4C!important;
 	cursor: url(https://fi.somethingawful.com/219/cosby/pudding_cursor.png), default;

--- a/src/219a.css
+++ b/src/219a.css
@@ -286,6 +286,10 @@ p.editedby span, p.attachment span, #copyright, #copyright * {
 	margin: 0
 }
 
+ul.postbuttons li:last-child {
+	display: none;
+}
+
 button.nice {
 	color: #EACF4C!important;
 	background-color: transparent;


### PR DESCRIPTION
This pull request dummies out the .cospop banner by marking its display type as none. Removing the "NICE!" button without adding a bunch of extra whitespace is also performed using a css :last-child pseudoclass hack.

This functionally resolves https://forums.somethingawful.com/showthread.php?threadid=4082607 from a user-facing perspective.