### PR TITLE
Fix issue where long thread title without word breaks can break the bookmarks page/user control panel

### DIFF
--- a/src/forums.css
+++ b/src/forums.css
@@ -3463,6 +3463,12 @@ td.title div.title_inner {
 	align-items: center;
 }
 
+tr.thread > td.title > div.title_inner > div.info {
+	/* fixes the the right side of the bookmarks page being pushed off the edge
+	   of the screen if a thread title is too long without a word break */
+	overflow-wrap: anywhere;
+}
+
 td.title div.lastseen {
 	float: none;
 	border: 1px solid #A8A7A7;


### PR DESCRIPTION
This PR adds a selector in the main forums CSS with the `overflow-wrap` property set to `anywhere` specifically for thread titles in the user control panel and bookmarks page. It fixes the rendering issue with overly long thread titles that don't have any word breaks (eg. spaces) as seen in https://forums.somethingawful.com/showthread.php?threadid=3910071&perpage=40&pagenumber=153#post550480046 wherein the right side of the bookmarks display area ends up being pushed rightwards and rendered off-screen.

Before:
<img width="941" height="189" alt="image" src="https://github.com/user-attachments/assets/dd95e3e5-12f4-4c79-a0ac-f9842cfd1cd7" />

After:
<img width="930" height="204" alt="image" src="https://github.com/user-attachments/assets/877d095f-51ae-4811-8734-a8f0acc15481" />

Tested in Chrome, Vivaldi, Firefox, Safari.